### PR TITLE
Address cli parameter parsing issue

### DIFF
--- a/lib/chef/knife/knife-node-attribute.rb
+++ b/lib/chef/knife/knife-node-attribute.rb
@@ -57,15 +57,16 @@ module KnifeNodeAttribute
       end
       if name_args[1].nil?
         attribute_class = :all
+        attribute_name = ""
       else
-        attribute_class = name_args[1].downcase.to_sym
+        attribute_class = name_args[1].downcase
         # if we passed a valid attribute class, the next one could be an
         # attribute name. If it's invalid, it might be the attribute name
-        if ATTRIBUTE_CLASSES.include? attribute_class
+        if ATTRIBUTE_CLASSES.include? attribute_class.to_sym
           attribute_name = name_args[2] || ""
         else
           attribute_name = attribute_class
-          attribute_class = :all
+          attribute_class = :default
         end
       end
 


### PR DESCRIPTION
When omitting an attribute level from the commandline, the script tries to
interpret whether there is no level or specific attribute name to search for,
or whether the operator put an attribute name in instead of a level. This
process was incorrectly using a symbol for the attribute name and trying to
look the name up at level :all, which ended up failing.

This change avoids the symbol convert and alters the code to look up at
:default by default.